### PR TITLE
Add CLI and fix hourly forecast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ python -m pip install -r requirements.txt
 To update all cached forecasts, run:
 
 ```bash
-python -c "import utils.api as api; api.update_all_forecasts()"
+python main.py update-all
+```
+
+You can also display the latest forecasts directly:
+
+```bash
+python main.py show-hourly  # hourly forecast
+python main.py show-daily   # 12-hour forecast
 ```
 
 Cached JSON files (`cached_forecast_data.json`, `cached_hourly_data.json`, and `cached_raw_data.json`) will be written in the repository root. You can explore or further process these files with the models in `utils/models.py`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,58 @@
+"""Command line interface for the weather utilities."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from utils import api
+
+
+def _print_hourly(data: dict) -> None:
+    """Print a simple summary of hourly forecast data."""
+    periods = data.get("properties", {}).get("periods", [])
+    for period in periods:
+        temp = period.get("temperature")
+        unit = period.get("temperatureUnit")
+        short = period.get("shortForecast")
+        start = period.get("startTime")
+        print(f"{start}: {temp}{unit} - {short}")
+
+
+def _print_daily(data: dict) -> None:
+    """Print a simple summary of 12 hour forecast data."""
+    periods = data.get("properties", {}).get("periods", [])
+    for period in periods:
+        name = period.get("name")
+        temp = period.get("temperature")
+        unit = period.get("temperatureUnit")
+        short = period.get("shortForecast")
+        print(f"{name}: {temp}{unit} - {short}")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """Entry point for the CLI."""
+    parser = argparse.ArgumentParser(description="Weather forecast utilities")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("update-all", help="Fetch and cache all forecasts")
+    sub.add_parser("show-hourly", help="Display the latest hourly forecast")
+    sub.add_parser("show-daily", help="Display the latest 12h forecast")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "update-all":
+        api.update_all_forecasts()
+    elif args.command == "show-hourly":
+        data = api.fetch_hourly_forecast()
+        _print_hourly(data)
+    elif args.command == "show-daily":
+        data = api.fetch_forecast()
+        _print_daily(data)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/api.py
+++ b/utils/api.py
@@ -72,7 +72,7 @@ def fetch_hourly_forecast() -> dict[str, dict]:
         dict[str, dict]: The JSON response from the API as a dictionary.
     """
     return requests.get(
-        BASE_URL + "forecast", headers={"User-Agent": USER_AGENT}
+        BASE_URL + "forecast/hourly", headers={"User-Agent": USER_AGENT}
     ).json()
 
 


### PR DESCRIPTION
## Summary
- implement command-line interface in `main.py` with `update-all`, `show-hourly`, and `show-daily` commands
- fix hourly forecast request to use `/forecast/hourly`
- document CLI usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855ce0eda548320bcce678c1d17eb0e